### PR TITLE
fix: switching cdn for rapidoc js-file

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -35,7 +35,7 @@
   <link rel="manifest" href="/site.webmanifest">
 
 
-  <script type="module" src="https://unpkg.com/rapidoc/dist/rapidoc-min.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/rapidoc/dist/rapidoc-min.js"></script>
 
   <script src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"
     integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>


### PR DESCRIPTION
This pull request includes a small change to the `docs/index.html` file. The change updates the source URL for the `rapidoc` script to use a different CDN.

* [`docs/index.html`](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL38-R38): Updated the `rapidoc` script source URL from `unpkg.com` to `jsdelivr.net`.