### PR TITLE
feat(ci): use sha instead of tag on steps

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -26,16 +26,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
         with:
           submodules: recursive
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b #v5.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b #v4.0.0
         with:
           path: docs/
 
@@ -48,4 +48,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e #v4.0.5

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
 
       - name: Download swagger.json from tibiadata-api-go release
-        uses: robinraju/release-downloader@v1.12
+        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 #v1.12
         with:
           repository: TibiaData/tibiadata-api-go
           tag: ${{ github.event.client_payload.tag_name }}
@@ -43,7 +43,7 @@ jobs:
           echo "${contents}" > docs/swagger-dev.json
 
       - name: Commit docs/swagger files to repo
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 #v9.1.4
         with:
           add: docs/swagger.json docs/swagger-dev.json
           message: automatic update of docs/swagger files (release ${{ github.event.client_payload.tag_name }})
@@ -53,6 +53,6 @@ jobs:
     needs: update
     steps:
       - name: Trigger github-pages workflow
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 #v3.0.0
         with:
           event-type: tibiadata-api-docs-deploy


### PR DESCRIPTION
This pull request updates several GitHub Actions in workflow files to use explicit commit SHAs for each action, rather than floating version tags. This change improves security and reliability by ensuring the workflows always use the intended action versions, preventing unexpected updates or breaking changes.

closes #18 